### PR TITLE
Fix history limit handling

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -176,7 +176,13 @@ async function handleGeneration(req: Request, res: Response): Promise<void> {
  */
 async function handleGetHistory(req: Request, res: Response): Promise<void> {
   try {
-    const limit = req.query.limit ? parseInt(req.query.limit as string, 10) : api.MAX_HISTORY_ITEMS;
+    let limit = api.MAX_HISTORY_ITEMS;
+    if (req.query.limit !== undefined) {
+      const parsed = parseInt(req.query.limit as string, 10);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        limit = parsed;
+      }
+    }
     const history = await storage.getPromptHistory(limit);
     const response: HistorySuccessResponse = { history };
     res.status(200).json(response);

--- a/server/tests/integration/api.test.ts
+++ b/server/tests/integration/api.test.ts
@@ -171,6 +171,44 @@ describe('API Integration Tests', () => {
       expect(response.status).toBe(200);
       expect(response.body.history.length).toBe(2);
     });
+
+    it('should use default limit when limit parameter is invalid', async () => {
+      // Add multiple history items
+      for (let i = 0; i < 3; i++) {
+        await storage.savePromptHistory({
+          prompt: `Test prompt ${i}`,
+          model: 'test-model',
+          timestamp: new Date(),
+          tokensUsed: 10,
+          parameters: {},
+          response: `Test response ${i}`
+        });
+      }
+
+      const response = await request(baseUrl).get('/api/history?limit=abc');
+
+      expect(response.status).toBe(200);
+      expect(response.body.history.length).toBe(3);
+    });
+
+    it('should use default limit when limit parameter is non-positive', async () => {
+      // Add multiple history items
+      for (let i = 0; i < 3; i++) {
+        await storage.savePromptHistory({
+          prompt: `Test prompt ${i}`,
+          model: 'test-model',
+          timestamp: new Date(),
+          tokensUsed: 10,
+          parameters: {},
+          response: `Test response ${i}`
+        });
+      }
+
+      const response = await request(baseUrl).get('/api/history?limit=0');
+
+      expect(response.status).toBe(200);
+      expect(response.body.history.length).toBe(3);
+    });
   });
   
   describe('DELETE /api/history', () => {


### PR DESCRIPTION
## Summary
- fix NaN handling for history request limit
- test bad history limit parameter
- handle non-positive history limits

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684077bc75f88332ab0a1c6c09d4b7a9